### PR TITLE
Resolve issue realted with abstract method getEditableConfigNames

### DIFF
--- a/src/Resources/skeleton/module/src/Plugin/Block/block.php.twig
+++ b/src/Resources/skeleton/module/src/Plugin/Block/block.php.twig
@@ -77,6 +77,11 @@ class {{class_name}} extends BlockBase {% if services is not empty %}implements 
   /**
    * {@inheritdoc}
    */
+  protected function getEditableConfigNames() {}
+
+  /**
+   * {@inheritdoc}
+   */
   public function build() {
     return [
       '#markup' => '{{label}}',


### PR DESCRIPTION
With latest version of Drupal 8.0.x  I got the following error

```
PHP Fatal error:  Class Drupal\multi_step\Form\MultiStepForm contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Drupal\Core\Form\ConfigFormBase::getEditableConfigNames)
```

I add in twig template for forms an empty implementation of method getEditableConfigNames()