### PR TITLE
generate:plugin:rest:resource systematically injects coding standard err...

### DIFF
--- a/src/Resources/skeleton/module/src/Plugin/Rest/Resource/rest.php.twig
+++ b/src/Resources/skeleton/module/src/Plugin/Rest/Resource/rest.php.twig
@@ -32,7 +32,6 @@ use Psr\Log\LoggerInterface;
  *   }
  * )
  */
-
 class {{ class_name }} extends ResourceBase
 {% endblock %}
 {% block class_variables %}
@@ -46,19 +45,19 @@ class {{ class_name }} extends ResourceBase
 
 {% block class_construct %}
   /**
-  * Constructs a Drupal\rest\Plugin\ResourceBase object.
-  *
-  * @param array $configuration
-  *   A configuration array containing information about the plugin instance.
-  * @param string $plugin_id
-  *   The plugin_id for the plugin instance.
-  * @param mixed $plugin_definition
-  *   The plugin implementation definition.
-  * @param array $serializer_formats
-  *   The available serialization formats.
-  * @param \Psr\Log\LoggerInterface $logger
-  *   A logger instance.
-  */
+   * Constructs a Drupal\rest\Plugin\ResourceBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param array $serializer_formats
+   *   The available serialization formats.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   A logger instance.
+   */
   public function __construct(
     array $configuration,
     $plugin_id,
@@ -90,7 +89,7 @@ class {{ class_name }} extends ResourceBase
 
 {% block class_methods %}
 {% for state in plugin_states %}
-  /*
+  /**
    * Responds to {{ state }} requests.
    *
    * Returns a list of bundles for specified entity.
@@ -104,7 +103,7 @@ class {{ class_name }} extends ResourceBase
     $response = new ResourceResponse();
 
     // You must to implement the logic of your REST Resource here.
-    // Use current user after pass authentication to validate access
+    // Use current user after pass authentication to validate access.
     /*if(!$this->currentUser->hasPermission($permission)) {
       throw new AccessDeniedHttpException();
     }*/
@@ -113,11 +112,11 @@ class {{ class_name }} extends ResourceBase
     $response->setStatusCode(ResourceResponse::HTTP_OK);
     $response->headers->set('Content-Type', 'text/html');
 
-    // prints the HTTP headers followed by the content
+    // Prints the HTTP headers followed by the content.
     $response->send();
 
-    // Throw an exception if it is required'
-    //throw new HttpException(t('Throw an exception if it is required'));
+    // Throw an exception if it is required.
+    // throw new HttpException(t('Throw an exception if it is required.'));
   }
 
 {% endfor %}


### PR DESCRIPTION
My mistake I originally post this is an drupal.org issue 

https://www.drupal.org/node/2418827

Here is the text from the issue..


I have been using generate:rest:resource at bit recently which I really like

it is time to give a little back and fix some errors that are reported by

phpcs --standrard=Drupal .
Here is a sample of the coding standard bugs I have fixed.

Comments must end in a full stop
/* must become /**
comments have indentation errors.

Another obvious error is that the class definition need to be transformed from

class Hello extends foo
{
Anyway I hope this helps

class Hello extends foo {
but that is a system wide issue and needs to solved in another issue.

