### PR TITLE
The list routes are now named collection routes.

### DIFF
--- a/src/Resources/skeleton/module/links.action-entity-content.yml.twig
+++ b/src/Resources/skeleton/module/links.action-entity-content.yml.twig
@@ -2,6 +2,6 @@ entity.{{ entity_name }}.add_form:
   route_name: entity.{{ entity_name }}.add_form
   title: 'Add {{ entity_class }}'
   appears_on:
-    - entity.{{ entity_name }}.list
+    - entity.{{ entity_name }}.collection
     - entity.{{ entity_name }}.canonical
 

--- a/src/Resources/skeleton/module/links.action-entity.yml.twig
+++ b/src/Resources/skeleton/module/links.action-entity.yml.twig
@@ -2,5 +2,5 @@ entity.{{ entity_name }}.add_form:
   route_name: 'entity.{{ entity_name }}.add_form'
   title: 'Add {{ entity_class }}'
   appears_on:
-    - entity.{{ entity_name }}.list
+    - entity.{{ entity_name }}.collection
 

--- a/src/Resources/skeleton/module/links.menu-entity-content.yml.twig
+++ b/src/Resources/skeleton/module/links.menu-entity-content.yml.twig
@@ -1,7 +1,7 @@
 # {{ entity_class }} menu items definition
-entity.{{ entity_name }}.list:
+entity.{{ entity_name }}.collection:
   title: '{{ entity_class }}: Listing'
-  route_name: entity.{{ entity_name }}.list
+  route_name: entity.{{ entity_name }}.collection
   description: 'List {{ entity_class }}'
 
 {{ entity_name }}.admin.structure.settings:

--- a/src/Resources/skeleton/module/routing-entity-content.yml.twig
+++ b/src/Resources/skeleton/module/routing-entity-content.yml.twig
@@ -7,7 +7,7 @@ entity.{{ entity_name }}.canonical:
   requirements:
     _entity_access: '{{ entity_name }}.view'
 
-entity.{{ entity_name }}.list:
+entity.{{ entity_name }}.collection:
   path: '/admin/{{ entity_name }}'
   defaults:
     _entity_list: '{{ entity_name }}'

--- a/src/Resources/skeleton/module/routing-entity.yml.twig
+++ b/src/Resources/skeleton/module/routing-entity.yml.twig
@@ -1,5 +1,5 @@
 # {{ entity_class }} routing definition
-entity.{{ entity_name }}.list:
+entity.{{ entity_name }}.collection:
   path: '/admin/config/system/{{ entity_name }}'
   defaults:
     _entity_list: '{{ entity_name }}'

--- a/src/Resources/skeleton/module/src/Entity/Form/entity-content-delete.php.twig
+++ b/src/Resources/skeleton/module/src/Entity/Form/entity-content-delete.php.twig
@@ -35,7 +35,7 @@ class {{ entity_class }}DeleteForm extends ContentEntityConfirmFormBase
    * {@inheritdoc}
    */
   public function getCancelUrl() {
-    return new Url('entity.{{ entity_name }}.list');
+    return new Url('entity.{{ entity_name }}.collection');
   }
 
   /**

--- a/src/Resources/skeleton/module/src/Entity/entity-content.php.twig
+++ b/src/Resources/skeleton/module/src/Entity/entity-content.php.twig
@@ -49,7 +49,8 @@ use Drupal\user\UserInterface;
  *   links = {
  *     "canonical" = "entity.{{ entity_name }}.canonical",
  *     "edit-form" = "entity.{{ entity_name }}.edit_form",
- *     "delete-form" = "entity.{{ entity_name }}.delete_form"
+ *     "delete-form" = "entity.{{ entity_name }}.delete_form",
+ *     "collection" = "entity.{{ entity_name }}.collection"
  *   },
  *   field_ui_base_route = "{{ entity_name }}.settings"
  * )

--- a/src/Resources/skeleton/module/src/Entity/entity.php.twig
+++ b/src/Resources/skeleton/module/src/Entity/entity.php.twig
@@ -37,7 +37,8 @@ use Drupal\{{ module }}\{{ entity_class }}Interface;
  *   },
  *   links = {
  *     "edit-form" = "entity.{{ entity_name }}.edit_form",
- *     "delete-form" = "entity.{{ entity_name }}.delete_form"
+ *     "delete-form" = "entity.{{ entity_name }}.delete_form",
+ *     "collection" = "entity.{{ entity_name }}.collection"
  *   }
  * )
  */

--- a/src/Resources/skeleton/module/src/Form/entity-delete.php.twig
+++ b/src/Resources/skeleton/module/src/Form/entity-delete.php.twig
@@ -33,7 +33,7 @@ class {{ entity_class }}DeleteForm extends EntityConfirmFormBase
   * {@inheritdoc}
   */
   public function getCancelUrl() {
-    return new Url('entity.{{ entity_name }}.list');
+    return new Url('entity.{{ entity_name }}.collection');
   }
 
   /**

--- a/src/Resources/skeleton/module/src/Form/entity.php.twig
+++ b/src/Resources/skeleton/module/src/Form/entity.php.twig
@@ -66,6 +66,6 @@ class {{ entity_class }}Form extends EntityForm
         '%label' => ${{ entity_name }}->label(),
       )));
     }
-    $form_state->setRedirect('entity.{{ entity_name }}.list');
+    $form_state->setRedirectUrl(${{ entity_name }}->urlInfo('collection'));
   }
 {% endblock %}


### PR DESCRIPTION
Tracking core:

- Replaced every .list with .collection
- Added the collection link template to the entity annotations
- Used the new preferred way of setting redirects:
```
-    $form_state->setRedirect('entity.{{ entity_name }}.list');
+    $form_state->setRedirectUrl(${{ entity_name }}->urlInfo('collection'));
```
Note that I didn't do the same to the delete form's getCancelUrl(), I only fixed the route name there, since the idea is to remove that whole class in another PR (core now has generic delete forms).