### PR TITLE
[config:export] Export site configuration results in a PHP Fatal error

### DIFF
--- a/config/translations/console.en.yml
+++ b/config/translations/console.en.yml
@@ -61,7 +61,7 @@ commands:
       arguments:
         directory: Define export directory to save configuration output.
       messages:
-        directory: Your configuration export file was stores in %s
+        directory: Your configuration export file was stored in %s
     debug:
       description: Show the current configuration.
       arguments:

--- a/src/Command/ConfigExportCommand.php
+++ b/src/Command/ConfigExportCommand.php
@@ -70,7 +70,6 @@ class ConfigExportCommand extends ContainerAwareCommand
         }
 
         $this->addSuccessMessage(
-          $output,
           sprintf($this->trans('commands.config.export.messages.directory'), $config_export_file)
         );
     }


### PR DESCRIPTION
This piece of code:
```
$this->addSuccessMessage(
  $output,
  sprintf($this->trans('commands.config.export.messages.directory'), $config_export_file)
);
```
is throwing an error:
```
PHP Fatal error:  Call to undefined function 
Symfony\Component\Console\Formatter\_drupal_get_last_caller() in 
/var/www/DrupalAppConsole/vendor/symfony/console/Symfony/Component/Console/
Formatter/OutputFormatter.php on line 37
```

It seems like $output var is obsolete in addSuccessMessage() as a string is need to be passed.