### PR TITLE
generate:entity:content produces inconsistent file annotation. #536

### DIFF
--- a/templates/module/src/accesscontrolhandler-entity-content.php.twig
+++ b/templates/module/src/accesscontrolhandler-entity-content.php.twig
@@ -1,7 +1,7 @@
 {% extends "base/class.php.twig" %}
 
 {% block file_path %}
-Drupal\account\{{ entity_class }}AccessController.
+Drupal\account\{{ entity_class }}AccessControlHandler.
 {% endblock %}
 
 {% block namespace_class %}


### PR DESCRIPTION
This is the fix for https://github.com/hechoendrupal/DrupalAppConsole/issues/536