### PR TITLE
Call kernel terminate in KernelHelper::terminate().

### DIFF
--- a/src/Command/Helper/KernelHelper.php
+++ b/src/Command/Helper/KernelHelper.php
@@ -86,6 +86,12 @@ class KernelHelper extends Helper
         return $this->kernel;
     }
 
+    public function terminate()
+    {
+        $response = Response::create('');
+        $this->kernel->terminate($this->request, $response);
+    }
+
     /**
      * @param \Drupal\Core\DrupalKernel $kernel
      */


### PR DESCRIPTION
  n.b. no one calls KernelHelper::terminate yet.  Do this later.

This will insure that Drupal has a chance to write any changes to the db, etc.; without this, you'll sometimes need to run a cache rebuild.

Copied from DrupalBoot8 in Drush.