### PR TITLE
Bootstrap refactor

### DIFF
--- a/src/Command/Helper/KernelHelper.php
+++ b/src/Command/Helper/KernelHelper.php
@@ -41,6 +41,11 @@ class KernelHelper extends Helper
     protected $debug;
 
     /**
+     * @var boolean
+     */
+    protected $booted;
+
+    /**
      * @param string $environment
      */
     public function setEnvironment($environment)
@@ -61,7 +66,7 @@ class KernelHelper extends Helper
      */
     public function bootKernel()
     {
-        if (!$this->kernel) {
+        if (!$this->booted) {
             $kernel = $this->getKernel();
             $kernel->boot();
             $kernel->preHandle($this->request);
@@ -69,6 +74,7 @@ class KernelHelper extends Helper
             $container = $kernel->getContainer();
             $container->set('request', $this->request);
             $container->get('request_stack')->push($this->request);
+            $this->booted = true;
         }
     }
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -79,16 +79,12 @@ class Application extends BaseApplication
     /**
      * Prepare Drupal Console to run, and bootstrap Drupal
      */
-    public function bootstrap($env = 'prod', $debug = false)
+    public function setup($env = 'prod', $debug = false)
     {
         if ($this->isBooted()) {
             if ($this->drupalAutoload) {
                 $this->initDebug($env, $debug);
                 $this->doKernelConfiguration();
-            }
-
-            if (!$this->commandsRegistered) {
-                $this->commandsRegistered = $this->registerCommands();
             }
         }
     }
@@ -108,7 +104,8 @@ class Application extends BaseApplication
 
         if (!$this->isBooted()) {
             $this->isRuningOnDrupalInstance($drupal_root);
-            $this->bootstrap($env, $debug);
+            $this->setup($env, $debug);
+            $this->bootstrap();
         }
 
         if ($this->isBooted()) {
@@ -236,8 +233,17 @@ class Application extends BaseApplication
 
         $kernelHelper->setClassLoader($this->drupalAutoload);
         $kernelHelper->setEnvironment($this->env);
+    }
+
+    public function bootstrap()
+    {
+        $kernelHelper = $this->getHelperSet()->get('kernel');
         $kernelHelper->bootKernel();
         $kernelHelper->initCommands($this->all());
+
+        if (!$this->commandsRegistered) {
+            $this->commandsRegistered = $this->registerCommands();
+        }
     }
 
     /**


### PR DESCRIPTION
Drush bootstraps in multiple phases.  Some commands only need to access Drupal configuration, while others need a full bootstrap, with the kernel booted, etc.

Currently, Drush creates the kernel object during bootstrap configuration, but it does not call $kernel->boot() until the bootstrap full phase.  This refactor splits the Drupal Console initialization into two parts in order to allows Drush to continue to do this.