### PR TITLE
[generate:entity:content] Prevent "Link templates accepts paths" exception with i18n

### DIFF
--- a/templates/module/src/Entity/entity-content.php.twig
+++ b/templates/module/src/Entity/entity-content.php.twig
@@ -48,10 +48,10 @@ use Drupal\user\UserInterface;
  *     "uuid" = "uuid"
  *   },
  *   links = {
- *     "canonical" = "entity.{{ entity_name }}.canonical",
- *     "edit-form" = "entity.{{ entity_name }}.edit_form",
- *     "delete-form" = "entity.{{ entity_name }}.delete_form",
- *     "collection" = "entity.{{ entity_name }}.collection"
+ *     "canonical" = "/entity.{{ entity_name }}.canonical",
+ *     "edit-form" = "/entity.{{ entity_name }}.edit_form",
+ *     "delete-form" = "/entity.{{ entity_name }}.delete_form",
+ *     "collection" = "/entity.{{ entity_name }}.collection"
  *   },
  *   field_ui_base_route = "{{ entity_name }}.settings"
  * )


### PR DESCRIPTION
Prevent "Link templates accepts paths, which have to start with a leading slash" exception when enabling content translation module

When you enable content translation module, and create a translatable entity with console, an exception is thrown by EntityType because there is no trailing slash at the begining of the path.